### PR TITLE
Revert "Bump library/golang from 1.22.5-bookworm to 1.24.2-bookworm in /go_modules"

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.2-bookworm as go
+FROM docker.io/library/golang:1.22.5-bookworm as go
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH


### PR DESCRIPTION
Reverts TM-ACode/dependabot-core#73